### PR TITLE
Fix yellow warning about requiresMainQueueSetup on iOS

### DIFF
--- a/ios/RCTSmartconfig/Smartconfig.m
+++ b/ios/RCTSmartconfig/Smartconfig.m
@@ -62,6 +62,12 @@ RCT_EXPORT_MODULE();
     }
     return self;
 }
+
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 RCT_EXPORT_METHOD(stop) {
     [self cancel];
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-smartconfig",
-  "version": "1.2",
+  "version": "1.0.2",
   "description": "react-native ESP8266 smartconfig module",
   "nativePackage": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-smartconfig",
-  "version": "0.2.2",
+  "version": "1.2",
   "description": "react-native ESP8266 smartconfig module",
   "nativePackage": true,
   "scripts": {


### PR DESCRIPTION
Fix Issue #7 

- fix the yellow warning on ios simulator
Module Smartconfig requires main queue setup
since it overrides `init` but doesn't implement `requiresMainQueueSetup`.
In a future release React Native will default to initializing
all native modules on a background thread unless explicitly opted-out of.